### PR TITLE
allow FAISS.load_local to allow loading content of trained_db

### DIFF
--- a/api.py
+++ b/api.py
@@ -78,7 +78,11 @@ async def chat_with_chatbot(payload:ChatPayload,x_author: str = Header(None)):
         embeddings = OpenAIEmbeddings()
         persist_directory = f'trained_db/chatbot'
         #Loading our VectorDatabase
-        Vectordb = FAISS.load_local(persist_directory,embeddings)
+        Vectordb = FAISS.load_localFAISS.load_local(
+            persist_directory,
+            embeddings,
+            allow_dangerous_deserialization = True
+        )
         #here is where the actual prompt template is intialize.
         _PROMPT = PromptTemplate(template=prompt_template, input_variables=["context", "question"])
         #Intializing our LLM.


### PR DESCRIPTION
To solve "The de-serialization relies loading a pickle file" caused by /trained_d/chatbot/index.pkl

Note: I wasn't able to test since I don't have this development for this project setup on my campus workstation but copied code from my working project.